### PR TITLE
Fix filter builder to avoid passing topics/addresses entries if there are none

### DIFF
--- a/ethereum/helpers.go
+++ b/ethereum/helpers.go
@@ -24,9 +24,12 @@ func toBlockNumArg(number *big.Int) string {
 }
 
 func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {
-	arg := map[string]interface{}{
-		"address": q.Addresses,
-		"topics":  q.Topics,
+	arg := make(map[string]interface{})
+	if len(q.Addresses) > 0 {
+		arg["addresses"] = q.Addresses
+	}
+	if len(q.Topics) > 0 {
+		arg["topics"] = q.Topics
 	}
 	if q.BlockHash != nil {
 		arg["blockHash"] = *q.BlockHash

--- a/ethereum/helpers_test.go
+++ b/ethereum/helpers_test.go
@@ -1,0 +1,32 @@
+package ethereum
+
+import (
+	"github.com/ethereum/go-ethereum"
+	"github.com/forta-network/forta-core-go/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestToFilterArg(t *testing.T) {
+	fromBlock, _ := utils.HexToBigInt("0x25beafb")
+	toBlock := fromBlock
+
+	q := ethereum.FilterQuery{
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Addresses: nil,
+		Topics:    nil,
+	}
+
+	result, err := toFilterArg(q)
+	assert.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	assert.True(t, ok)
+
+	_, addrExists := m["addresses"]
+	assert.False(t, addrExists)
+
+	_, topicsExists := m["topics"]
+	assert.False(t, topicsExists)
+}


### PR DESCRIPTION
- Fantom is not tolerant to empty Address and Topic parameters in getLogs queries