### PR TITLE
Add links to the swagger alert model

### DIFF
--- a/clients/webhook/client/models/alert.go
+++ b/clients/webhook/client/models/alert.go
@@ -44,6 +44,10 @@ type Alert struct {
 	// Example: 0xe9cfda18f167de5cdd63c101e38ec0d4cb0a1c2dea80921ecc4405c2b010855f
 	Hash string `json:"hash,omitempty"`
 
+	// An associative array of extra links values
+	// Example: {"blockUrl":"https://etherscan.io/block/18646150","explorerUrl":"https://explorer.forta.network/alert/0xd795c365931762afeccf4a440ecee2f7e89820c59136aa46310a8eec54ba96d8"}
+	Links interface{} `json:"links,omitempty"`
+
 	// An associative array of string values
 	// Example: {"contractAddress":"0x98883145049dec03c00cb7708cbc938058802520","operator":"0x1fFa3471A45C22B1284fE5a251eD74F40580a1E3"}
 	Metadata interface{} `json:"metadata,omitempty"`

--- a/clients/webhook/client/operations/send_alerts_parameters.go
+++ b/clients/webhook/client/operations/send_alerts_parameters.go
@@ -67,6 +67,12 @@ type SendAlertsParams struct {
 	*/
 	Authorization *string
 
+	/* XRequestSignature.
+
+	   Webhook request validation signature
+	*/
+	XRequestSignature *string
+
 	// AlertList.
 	AlertList *models.AlertList
 
@@ -134,6 +140,17 @@ func (o *SendAlertsParams) SetAuthorization(authorization *string) {
 	o.Authorization = authorization
 }
 
+// WithXRequestSignature adds the xRequestSignature to the send alerts params
+func (o *SendAlertsParams) WithXRequestSignature(xRequestSignature *string) *SendAlertsParams {
+	o.SetXRequestSignature(xRequestSignature)
+	return o
+}
+
+// SetXRequestSignature adds the xRequestSignature to the send alerts params
+func (o *SendAlertsParams) SetXRequestSignature(xRequestSignature *string) {
+	o.XRequestSignature = xRequestSignature
+}
+
 // WithAlertList adds the alertList to the send alerts params
 func (o *SendAlertsParams) WithAlertList(alertList *models.AlertList) *SendAlertsParams {
 	o.SetAlertList(alertList)
@@ -157,6 +174,14 @@ func (o *SendAlertsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 
 		// header param Authorization
 		if err := r.SetHeaderParam("Authorization", *o.Authorization); err != nil {
+			return err
+		}
+	}
+
+	if o.XRequestSignature != nil {
+
+		// header param X-Request-Signature
+		if err := r.SetHeaderParam("X-Request-Signature", *o.XRequestSignature); err != nil {
 			return err
 		}
 	}

--- a/clients/webhook/client/operations/send_alerts_parameters.go
+++ b/clients/webhook/client/operations/send_alerts_parameters.go
@@ -67,12 +67,6 @@ type SendAlertsParams struct {
 	*/
 	Authorization *string
 
-	/* XRequestSignature.
-
-	   Webhook request validation signature
-	*/
-	XRequestSignature *string
-
 	// AlertList.
 	AlertList *models.AlertList
 
@@ -140,17 +134,6 @@ func (o *SendAlertsParams) SetAuthorization(authorization *string) {
 	o.Authorization = authorization
 }
 
-// WithXRequestSignature adds the xRequestSignature to the send alerts params
-func (o *SendAlertsParams) WithXRequestSignature(xRequestSignature *string) *SendAlertsParams {
-	o.SetXRequestSignature(xRequestSignature)
-	return o
-}
-
-// SetXRequestSignature adds the xRequestSignature to the send alerts params
-func (o *SendAlertsParams) SetXRequestSignature(xRequestSignature *string) {
-	o.XRequestSignature = xRequestSignature
-}
-
 // WithAlertList adds the alertList to the send alerts params
 func (o *SendAlertsParams) WithAlertList(alertList *models.AlertList) *SendAlertsParams {
 	o.SetAlertList(alertList)
@@ -174,14 +157,6 @@ func (o *SendAlertsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 
 		// header param Authorization
 		if err := r.SetHeaderParam("Authorization", *o.Authorization); err != nil {
-			return err
-		}
-	}
-
-	if o.XRequestSignature != nil {
-
-		// header param X-Request-Signature
-		if err := r.SetHeaderParam("X-Request-Signature", *o.XRequestSignature); err != nil {
 			return err
 		}
 	}

--- a/protocol/webhook/swagger.yml
+++ b/protocol/webhook/swagger.yml
@@ -101,6 +101,12 @@ definitions:
         example:
           contractAddress: '0x98883145049dec03c00cb7708cbc938058802520'
           operator: '0x1fFa3471A45C22B1284fE5a251eD74F40580a1E3'
+      links:
+        type: object
+        description: An associative array of extra links values
+        example:
+          explorerUrl: 'https://explorer.forta.network/alert/0xd795c365931762afeccf4a440ecee2f7e89820c59136aa46310a8eec54ba96d8'
+          blockUrl: 'https://etherscan.io/block/18646150'
       source:
         $ref: '#/definitions/AlertSource'
       addresses:

--- a/protocol/webhook/swagger.yml
+++ b/protocol/webhook/swagger.yml
@@ -24,10 +24,6 @@ paths:
           name: Authorization
           description: Webhook request authorization
           type: string
-        - in: header
-          name: X-Request-Signature
-          description: Webhook request validation signature
-          type: string
         - in: body
           name: alertList
           required: true

--- a/protocol/webhook/swagger.yml
+++ b/protocol/webhook/swagger.yml
@@ -24,6 +24,10 @@ paths:
           name: Authorization
           description: Webhook request authorization
           type: string
+        - in: header
+          name: X-Request-Signature
+          description: Webhook request validation signature
+          type: string
         - in: body
           name: alertList
           required: true


### PR DESCRIPTION
When sending webhook alerts, we make it easier for recipients to get extra links that will be useful to quickly access data.

See https://github.com/forta-network/forta-analyzer/issues/178 as well for header changes