### PR TITLE
Add reward threshold and safe offsets

### DIFF
--- a/protocol/settings/chain_test.go
+++ b/protocol/settings/chain_test.go
@@ -1,0 +1,17 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateChainSettings(t *testing.T) {
+	for _, chainSettings := range allChainSettings {
+		t.Run(chainSettings.Name, func(t *testing.T) {
+			r := require.New(t)
+
+			r.True(ValidateChainSettings(chainSettings.ChainID))
+		})
+	}
+}


### PR DESCRIPTION
- Move reward thresholds to chain settings in this repo
- Base safe offsets on 5-10% of reward threshold
- Add tests to validate chain settings (especially safe offset and reward threshold relationship)

The safe offsets allow us to use block feed offsets in node when scan API needs to follow from behind.