### PR TITLE
Change Ethereum default offset to 1

### DIFF
--- a/protocol/settings/chain.go
+++ b/protocol/settings/chain.go
@@ -36,7 +36,7 @@ var allChainSettings = []ChainSettings{
 		JsonRpcRateLimiting: defaultRateLimiting,
 		InspectionInterval:  50,
 
-		DefaultOffset:   0,
+		DefaultOffset:   1,
 		SafeOffset:      1,
 		RewardThreshold: 20,
 	},


### PR DESCRIPTION
Helps avoid excessive `trace_block` retries (50%)