### PR TITLE
Add helper methods to client

### DIFF
--- a/feeds/mocks/mock_feeds.go
+++ b/feeds/mocks/mock_feeds.go
@@ -270,30 +270,18 @@ func (mr *MockAlertFeedMockRecorder) Start() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockAlertFeed)(nil).Start))
 }
 
-// StartRange mocks base method.
-func (m *MockAlertFeed) StartRange(start, end uint64, rate int64) {
+// Subscriptions mocks base method.
+func (m *MockAlertFeed) Subscriptions() []*protocol.CombinerBotSubscription {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartRange", start, end, rate)
-}
-
-// StartRange indicates an expected call of StartRange.
-func (mr *MockAlertFeedMockRecorder) StartRange(start, end, rate interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRange", reflect.TypeOf((*MockAlertFeed)(nil).StartRange), start, end, rate)
-}
-
-// SubscribedBots mocks base method.
-func (m *MockAlertFeed) SubscribedBots() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscribedBots")
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "Subscriptions")
+	ret0, _ := ret[0].([]*protocol.CombinerBotSubscription)
 	return ret0
 }
 
-// SubscribedBots indicates an expected call of SubscribedBots.
-func (mr *MockAlertFeedMockRecorder) SubscribedBots() *gomock.Call {
+// Subscriptions indicates an expected call of Subscriptions.
+func (mr *MockAlertFeedMockRecorder) Subscriptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribedBots", reflect.TypeOf((*MockAlertFeed)(nil).SubscribedBots))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscriptions", reflect.TypeOf((*MockAlertFeed)(nil).Subscriptions))
 }
 
 // MockLogFeed is a mock of LogFeed interface.

--- a/registry/client.go
+++ b/registry/client.go
@@ -559,6 +559,9 @@ func (c *client) IndexOfAssignedScanner(agentID, scannerID string) (*big.Int, er
 	aID := utils.AgentHexToBigInt(agentID)
 	sID := utils.ScannerIDHexToBigInt(scannerID)
 	length, err := c.dp.NumScannersFor(opts, aID)
+	if err != nil {
+		return nil, err
+	}
 	for i := int64(0); i < length.Int64(); i++ {
 		idx := big.NewInt(i)
 		scn, err := c.dp.ScannerRefAt(opts, aID, idx)

--- a/registry/client.go
+++ b/registry/client.go
@@ -100,6 +100,9 @@ type Client interface {
 	// ForEachAssignedScanner loops over scanners by agent
 	ForEachAssignedScanner(agentID string, handler func(s *Scanner) error) error
 
+	// IndexOfAssignedScanner gets index of assigned scanner
+	IndexOfAssignedScanner(agentID, scannerID string) (*big.Int, error)
+
 	// GetStakingThreshold returns the min/max/activated flag for a given address
 	GetStakingThreshold(scannerID string) (*StakingThreshold, error)
 
@@ -537,6 +540,36 @@ func (c *client) ForEachAssignedScanner(agentID string, handler func(s *Scanner)
 		}
 	}
 	return nil
+}
+
+func (c *client) ActiveAgentStake(agentID string) (*big.Int, error) {
+	opts, err := c.getOps()
+	if err != nil {
+		return nil, err
+	}
+	id := utils.AgentHexToBigInt(agentID)
+	return c.fs.ActiveStakeFor(opts, 2, id)
+}
+
+func (c *client) IndexOfAssignedScanner(agentID, scannerID string) (*big.Int, error) {
+	opts, err := c.getOps()
+	if err != nil {
+		return nil, err
+	}
+	aID := utils.AgentHexToBigInt(agentID)
+	sID := utils.ScannerIDHexToBigInt(scannerID)
+	length, err := c.dp.NumScannersFor(opts, aID)
+	for i := int64(0); i < length.Int64(); i++ {
+		idx := big.NewInt(i)
+		scn, err := c.dp.ScannerRefAt(opts, aID, idx)
+		if err != nil {
+			return nil, err
+		}
+		if scn.ScannerId.Cmp(sID) == 0 {
+			return big.NewInt(i), nil
+		}
+	}
+	return nil, nil
 }
 
 func (c *client) ForEachAssignedAgent(scannerID string, handler func(a *Agent) error) error {

--- a/registry/mocks/mock_client.go
+++ b/registry/mocks/mock_client.go
@@ -270,6 +270,21 @@ func (mr *MockClientMockRecorder) GetStakingThreshold(scannerID interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStakingThreshold", reflect.TypeOf((*MockClient)(nil).GetStakingThreshold), scannerID)
 }
 
+// IndexOfAssignedScanner mocks base method.
+func (m *MockClient) IndexOfAssignedScanner(agentID, scannerID string) (*big.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexOfAssignedScanner", agentID, scannerID)
+	ret0, _ := ret[0].(*big.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexOfAssignedScanner indicates an expected call of IndexOfAssignedScanner.
+func (mr *MockClientMockRecorder) IndexOfAssignedScanner(agentID, scannerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexOfAssignedScanner", reflect.TypeOf((*MockClient)(nil).IndexOfAssignedScanner), agentID, scannerID)
+}
+
 // IsAssigned mocks base method.
 func (m *MockClient) IsAssigned(scannerID, agentID string) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- gets active stake for bot (for scripts)
- gets index of an assigned scanner for a given bot 