### PR TITLE
Obtain the closest block to a time

### DIFF
--- a/ethereum/client.go
+++ b/ethereum/client.go
@@ -48,6 +48,10 @@ type Client interface {
 	SubscribeToHead(ctx context.Context) (domain.HeaderCh, error)
 
 	health.Reporter
+
+	GetClosestBlock(ctx context.Context, activeTime time.Time) (*domain.Block, error)
+	GetClosestBlockBefore(ctx context.Context, activeTime time.Time) (*domain.Block, error)
+	GetClosestBlockAfter(ctx context.Context, activeTime time.Time) (*domain.Block, error)
 }
 
 const blocksByNumber = "eth_getBlockByNumber"

--- a/ethereum/closest_block.go
+++ b/ethereum/closest_block.go
@@ -1,15 +1,15 @@
-package utils
+package ethereum
 
 import (
 	"context"
 	"github.com/forta-network/forta-core-go/domain"
-	"github.com/forta-network/forta-core-go/ethereum"
+	"github.com/forta-network/forta-core-go/utils"
 	"math/big"
 	"time"
 )
 
 // GetClosestBlock Obtains the block closest to the time given
-func GetClosestBlock(ctx context.Context, eth ethereum.Client, activeTime time.Time) (*domain.Block, error) {
+func GetClosestBlock(ctx context.Context, eth Client, activeTime time.Time) (*domain.Block, error) {
 
 	minBlockNumber := big.NewInt(0)
 	maxBlockNumber, err := eth.BlockNumber(ctx)
@@ -49,7 +49,7 @@ func GetClosestBlock(ctx context.Context, eth ethereum.Client, activeTime time.T
 }
 
 // GetClosestBlockBefore Obtains the closest block only before the current active time
-func GetClosestBlockBefore(ctx context.Context, eth ethereum.Client, activeTime time.Time) (*domain.Block, error) {
+func GetClosestBlockBefore(ctx context.Context, eth Client, activeTime time.Time) (*domain.Block, error) {
 	closestBlock, err := GetClosestBlock(ctx, eth, activeTime)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func GetClosestBlockBefore(ctx context.Context, eth ethereum.Client, activeTime 
 	if closestBlockTime.Equal(activeTime) || closestBlockTime.Before(activeTime) {
 		return closestBlock, nil
 	}
-	closestBlockNumber, err := HexToBigInt(closestBlock.Number)
+	closestBlockNumber, err := utils.HexToBigInt(closestBlock.Number)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func GetClosestBlockBefore(ctx context.Context, eth ethereum.Client, activeTime 
 }
 
 // GetClosestBlockAfter Obtains the closest block only after the current active time
-func GetClosestBlockAfter(ctx context.Context, eth ethereum.Client, activeTime time.Time) (*domain.Block, error) {
+func GetClosestBlockAfter(ctx context.Context, eth Client, activeTime time.Time) (*domain.Block, error) {
 	closestBlock, err := GetClosestBlock(ctx, eth, activeTime)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func GetClosestBlockAfter(ctx context.Context, eth ethereum.Client, activeTime t
 	if closestBlockTime.Equal(activeTime) || closestBlockTime.After(activeTime) {
 		return closestBlock, nil
 	}
-	closestBlockNumber, err := HexToBigInt(closestBlock.Number)
+	closestBlockNumber, err := utils.HexToBigInt(closestBlock.Number)
 	if err != nil {
 		return nil, err
 	}

--- a/ethereum/closest_block.go
+++ b/ethereum/closest_block.go
@@ -9,16 +9,16 @@ import (
 )
 
 // GetClosestBlock Obtains the block closest to the time given
-func GetClosestBlock(ctx context.Context, eth Client, activeTime time.Time) (*domain.Block, error) {
+func (e *streamEthClient) GetClosestBlock(ctx context.Context, activeTime time.Time) (*domain.Block, error) {
 
 	minBlockNumber := big.NewInt(0)
-	maxBlockNumber, err := eth.BlockNumber(ctx)
+	maxBlockNumber, err := e.BlockNumber(ctx)
 	if err != nil {
 		return nil, err
 	}
 	closestBlockNumber := new(big.Int).Add(maxBlockNumber, minBlockNumber)
 	closestBlockNumber = closestBlockNumber.Div(closestBlockNumber, big.NewInt(2))
-	closestBlock, err := eth.BlockByNumber(ctx, closestBlockNumber)
+	closestBlock, err := e.BlockByNumber(ctx, closestBlockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func GetClosestBlock(ctx context.Context, eth Client, activeTime time.Time) (*do
 
 		closestBlockNumber = new(big.Int).Add(maxBlockNumber, minBlockNumber)
 		closestBlockNumber = closestBlockNumber.Div(closestBlockNumber, big.NewInt(2))
-		closestBlock, err = eth.BlockByNumber(ctx, closestBlockNumber)
+		closestBlock, err = e.BlockByNumber(ctx, closestBlockNumber)
 		if err != nil {
 			return nil, err
 		}
@@ -49,8 +49,8 @@ func GetClosestBlock(ctx context.Context, eth Client, activeTime time.Time) (*do
 }
 
 // GetClosestBlockBefore Obtains the closest block only before the current active time
-func GetClosestBlockBefore(ctx context.Context, eth Client, activeTime time.Time) (*domain.Block, error) {
-	closestBlock, err := GetClosestBlock(ctx, eth, activeTime)
+func (e *streamEthClient) GetClosestBlockBefore(ctx context.Context, activeTime time.Time) (*domain.Block, error) {
+	closestBlock, err := e.GetClosestBlock(ctx, activeTime)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +68,12 @@ func GetClosestBlockBefore(ctx context.Context, eth Client, activeTime time.Time
 		return nil, err
 	}
 	closestBlockNumberBefore := big.NewInt(0).Sub(closestBlockNumber, big.NewInt(1))
-	return eth.BlockByNumber(ctx, closestBlockNumberBefore)
+	return e.BlockByNumber(ctx, closestBlockNumberBefore)
 }
 
 // GetClosestBlockAfter Obtains the closest block only after the current active time
-func GetClosestBlockAfter(ctx context.Context, eth Client, activeTime time.Time) (*domain.Block, error) {
-	closestBlock, err := GetClosestBlock(ctx, eth, activeTime)
+func (e *streamEthClient) GetClosestBlockAfter(ctx context.Context, activeTime time.Time) (*domain.Block, error) {
+	closestBlock, err := e.GetClosestBlock(ctx, activeTime)
 	if err != nil {
 		return nil, err
 	}
@@ -91,5 +91,5 @@ func GetClosestBlockAfter(ctx context.Context, eth Client, activeTime time.Time)
 		return nil, err
 	}
 	closestBlockNumberBefore := big.NewInt(0).Add(closestBlockNumber, big.NewInt(1))
-	return eth.BlockByNumber(ctx, closestBlockNumberBefore)
+	return e.BlockByNumber(ctx, closestBlockNumberBefore)
 }

--- a/ethereum/closest_block_test.go
+++ b/ethereum/closest_block_test.go
@@ -77,7 +77,9 @@ func TestGetClosestBlock(t *testing.T) {
 				return
 			}
 			result, err := utils.HexToBigInt(got.Number)
-
+			if !tt.wantErr(t, err, fmt.Sprintf("HexToBigInt( %v)", got.Number)) {
+				return
+			}
 			assert.Equalf(t, big.NewInt(tt.want), result, "GetClosestBlock( @ %v)", tt.activeTime)
 		})
 	}
@@ -120,7 +122,9 @@ func TestGetClosestBlockAfter(t *testing.T) {
 				return
 			}
 			result, err := utils.HexToBigInt(got.Number)
-
+			if !tt.wantErr(t, err, fmt.Sprintf("HexToBigInt( %v)", got.Number)) {
+				return
+			}
 			assert.Equalf(t, big.NewInt(tt.want), result, "GetClosestBlockAfter(@  %v)", tt.activeTime)
 		})
 	}
@@ -157,6 +161,9 @@ func TestGetClosestBlockBefore(t *testing.T) {
 			}
 
 			result, err := utils.HexToBigInt(got.Number)
+			if !tt.wantErr(t, err, fmt.Sprintf("HexToBigInt( %v)", got.Number)) {
+				return
+			}
 
 			assert.Equalf(t, big.NewInt(tt.want), result, "GetClosestBlockBefore( @ %v)", tt.activeTime)
 		})

--- a/ethereum/closest_block_test.go
+++ b/ethereum/closest_block_test.go
@@ -1,0 +1,164 @@
+package ethereum
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/forta-network/forta-core-go/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestRandomBlocks(t *testing.T) {
+
+	ctx := context.Background()
+	rawurl := "https://rpc.ankr.com/eth"
+	client, err := ethclient.Dial(rawurl)
+	if err != nil {
+		t.Error(fmt.Errorf("failed to dial: %v", err))
+		return
+	}
+
+	for _, i := range []int64{16390016, 16390015, 8145008, 4072504, 2036252, 2036262} {
+
+		b, err := client.BlockByNumber(ctx, big.NewInt(i))
+		if err != nil {
+			t.Error(fmt.Errorf("failed to get latest block number: %v", err))
+			return
+		}
+
+		log.Infof("Got block : %d  -  %d  %s", b.Number(), b.Time(), time.Unix(int64(b.Time()), 0).String())
+	}
+
+}
+
+func TestGetClosestBlock(t *testing.T) {
+
+	ankrUrl := "https://rpc.ankr.com/eth"
+	ctx := context.Background()
+	eth, err := NewStreamEthClient(ctx, "ankr", ankrUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	tests := []struct {
+		name       string
+		activeTime time.Time
+		want       int64
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name:       "Most recent",
+			activeTime: time.Unix(1673517970, 0),
+			want:       16390015,
+			wantErr:    assert.NoError,
+		},
+		{
+			name:       "Further away",
+			activeTime: time.Unix(1563052013, 0),
+			want:       8145008,
+			wantErr:    assert.NoError,
+		},
+		{
+			name:       "Exact time",
+			activeTime: time.Unix(1501002503, 0),
+			want:       4072504,
+			wantErr:    assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := eth.GetClosestBlock(ctx, tt.activeTime)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetClosestBlock( @ %v)", tt.activeTime)) {
+				return
+			}
+			result, err := utils.HexToBigInt(got.Number)
+
+			assert.Equalf(t, big.NewInt(tt.want), result, "GetClosestBlock( @ %v)", tt.activeTime)
+		})
+	}
+}
+
+func TestGetClosestBlockAfter(t *testing.T) {
+
+	ankrUrl := "https://rpc.ankr.com/eth"
+	ctx := context.Background()
+	eth, err := NewStreamEthClient(ctx, "ankr", ankrUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	tests := []struct {
+		name       string
+		activeTime time.Time
+		want       int64
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name:       "Exact current",
+			activeTime: time.Unix(1470690792, 0),
+			want:       2036252,
+			wantErr:    assert.NoError,
+		},
+
+		{
+			name:       "After current",
+			activeTime: time.Unix(1470690790, 0),
+			want:       2036252,
+			wantErr:    assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := eth.GetClosestBlockAfter(ctx, tt.activeTime)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetClosestBlockAfter( @ %v)", tt.activeTime)) {
+				return
+			}
+			result, err := utils.HexToBigInt(got.Number)
+
+			assert.Equalf(t, big.NewInt(tt.want), result, "GetClosestBlockAfter(@  %v)", tt.activeTime)
+		})
+	}
+}
+
+func TestGetClosestBlockBefore(t *testing.T) {
+
+	ankrUrl := "https://rpc.ankr.com/eth"
+	ctx := context.Background()
+	eth, err := NewStreamEthClient(ctx, "ankr", ankrUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	tests := []struct {
+		name       string
+		activeTime time.Time
+		want       int64
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name:       "Before Current",
+			activeTime: time.Unix(1470691013, 0),
+			want:       2036262,
+			wantErr:    assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := eth.GetClosestBlockBefore(ctx, tt.activeTime)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetClosestBlockBefore( @ %v)", tt.activeTime)) {
+				return
+			}
+
+			result, err := utils.HexToBigInt(got.Number)
+
+			assert.Equalf(t, big.NewInt(tt.want), result, "GetClosestBlockBefore( @ %v)", tt.activeTime)
+		})
+	}
+}

--- a/ethereum/mocks/mock_client.go
+++ b/ethereum/mocks/mock_client.go
@@ -186,6 +186,51 @@ func (mr *MockClientMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close))
 }
 
+// GetClosestBlock mocks base method.
+func (m *MockClient) GetClosestBlock(ctx context.Context, activeTime time.Time) (*domain.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClosestBlock", ctx, activeTime)
+	ret0, _ := ret[0].(*domain.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClosestBlock indicates an expected call of GetClosestBlock.
+func (mr *MockClientMockRecorder) GetClosestBlock(ctx, activeTime interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClosestBlock", reflect.TypeOf((*MockClient)(nil).GetClosestBlock), ctx, activeTime)
+}
+
+// GetClosestBlockAfter mocks base method.
+func (m *MockClient) GetClosestBlockAfter(ctx context.Context, activeTime time.Time) (*domain.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClosestBlockAfter", ctx, activeTime)
+	ret0, _ := ret[0].(*domain.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClosestBlockAfter indicates an expected call of GetClosestBlockAfter.
+func (mr *MockClientMockRecorder) GetClosestBlockAfter(ctx, activeTime interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClosestBlockAfter", reflect.TypeOf((*MockClient)(nil).GetClosestBlockAfter), ctx, activeTime)
+}
+
+// GetClosestBlockBefore mocks base method.
+func (m *MockClient) GetClosestBlockBefore(ctx context.Context, activeTime time.Time) (*domain.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClosestBlockBefore", ctx, activeTime)
+	ret0, _ := ret[0].(*domain.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClosestBlockBefore indicates an expected call of GetClosestBlockBefore.
+func (mr *MockClientMockRecorder) GetClosestBlockBefore(ctx, activeTime interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClosestBlockBefore", reflect.TypeOf((*MockClient)(nil).GetClosestBlockBefore), ctx, activeTime)
+}
+
 // GetLogs mocks base method.
 func (m *MockClient) GetLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
 	m.ctrl.T.Helper()

--- a/feeds/mocks/mock_feeds.go
+++ b/feeds/mocks/mock_feeds.go
@@ -270,30 +270,18 @@ func (mr *MockAlertFeedMockRecorder) Start() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockAlertFeed)(nil).Start))
 }
 
-// StartRange mocks base method.
-func (m *MockAlertFeed) StartRange(start, end uint64, rate int64) {
+// Subscriptions mocks base method.
+func (m *MockAlertFeed) Subscriptions() []*protocol.CombinerBotSubscription {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartRange", start, end, rate)
-}
-
-// StartRange indicates an expected call of StartRange.
-func (mr *MockAlertFeedMockRecorder) StartRange(start, end, rate interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRange", reflect.TypeOf((*MockAlertFeed)(nil).StartRange), start, end, rate)
-}
-
-// SubscribedBots mocks base method.
-func (m *MockAlertFeed) SubscribedBots() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscribedBots")
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "Subscriptions")
+	ret0, _ := ret[0].([]*protocol.CombinerBotSubscription)
 	return ret0
 }
 
-// SubscribedBots indicates an expected call of SubscribedBots.
-func (mr *MockAlertFeedMockRecorder) SubscribedBots() *gomock.Call {
+// Subscriptions indicates an expected call of Subscriptions.
+func (mr *MockAlertFeedMockRecorder) Subscriptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribedBots", reflect.TypeOf((*MockAlertFeed)(nil).SubscribedBots))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscriptions", reflect.TypeOf((*MockAlertFeed)(nil).Subscriptions))
 }
 
 // MockLogFeed is a mock of LogFeed interface.

--- a/utils/closest_block.go
+++ b/utils/closest_block.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"context"
+	"github.com/forta-network/forta-core-go/domain"
+	"github.com/forta-network/forta-core-go/ethereum"
+	"math/big"
+	"strconv"
+	"time"
+)
+
+// GetClosestBlock Obtains the block closest to the time given
+func GetClosestBlock(ctx context.Context, eth ethereum.Client, activeTime time.Time) (*domain.Block, error) {
+
+	activeTimestamp := activeTime.UnixMilli()
+
+	minBlockNumber := big.NewInt(0)
+	maxBlockNumber, err := eth.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+	closestBlockNumber := new(big.Int).Add(maxBlockNumber, minBlockNumber)
+	closestBlockNumber = closestBlockNumber.Div(closestBlockNumber, big.NewInt(2))
+	closestBlock, err := eth.BlockByNumber(ctx, closestBlockNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	for minBlockNumber.Cmp(maxBlockNumber) <= 0 {
+		closestBlockTimestamp64, err := strconv.ParseInt(closestBlock.Timestamp[2:], 16, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		if closestBlockTimestamp64 == activeTimestamp {
+			break
+		} else if closestBlockTimestamp64 > activeTimestamp {
+			maxBlockNumber = maxBlockNumber.Sub(closestBlockNumber, big.NewInt(1))
+		} else {
+			minBlockNumber = minBlockNumber.Add(closestBlockNumber, big.NewInt(1))
+		}
+
+		closestBlockNumber = new(big.Int).Add(maxBlockNumber, minBlockNumber)
+		closestBlockNumber = closestBlockNumber.Div(closestBlockNumber, big.NewInt(2))
+		closestBlock, err = eth.BlockByNumber(ctx, closestBlockNumber)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return closestBlock, nil
+}
+
+// GetClosestBlockBefore Obtains the closest block only before the current active time
+func GetClosestBlockBefore(ctx context.Context, eth ethereum.Client, activeTime time.Time) (*domain.Block, error) {
+	closestBlock, err := GetClosestBlock(ctx, eth, activeTime)
+	if err != nil {
+		return nil, err
+	}
+
+	closestBlockTimestamp64, err := strconv.ParseInt(closestBlock.Timestamp[2:], 16, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	if closestBlockTimestamp64 <= activeTime.UnixMilli() {
+		return closestBlock, nil
+	}
+	closestBlockNumber, err := HexToBigInt(closestBlock.Number)
+	if err != nil {
+		return nil, err
+	}
+	closestBlockNumberBefore := big.NewInt(0).Sub(closestBlockNumber, big.NewInt(1))
+	return eth.BlockByNumber(ctx, closestBlockNumberBefore)
+}
+
+// GetClosestBlockAfter Obtains the closest block only after the current active time
+func GetClosestBlockAfter(ctx context.Context, eth ethereum.Client, activeTime time.Time) (*domain.Block, error) {
+	closestBlock, err := GetClosestBlock(ctx, eth, activeTime)
+	if err != nil {
+		return nil, err
+	}
+
+	closestBlockTimestamp64, err := strconv.ParseInt(closestBlock.Timestamp[2:], 16, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	if closestBlockTimestamp64 >= activeTime.UnixMilli() {
+		return closestBlock, nil
+	}
+	closestBlockNumber, err := HexToBigInt(closestBlock.Number)
+	if err != nil {
+		return nil, err
+	}
+	closestBlockNumberBefore := big.NewInt(0).Add(closestBlockNumber, big.NewInt(1))
+	return eth.BlockByNumber(ctx, closestBlockNumberBefore)
+}


### PR DESCRIPTION
PR adds three utility methods :

 1. GetClosestBlock - Obtains the block closest to a particular time of interest
 2. GetClosestBlockBefore - Obtains the block closest to a particular time however only at the exact time or just before the time 
 3. GetClosestBlockAfter - Obtains the block closest to a particular time but only at the exact time or just after 

2 and 3 are useful during calculations that involve periods e.g. 
```

Let's imagine:
- start minute M1: blocks B1, B2, B3, B4
- end minute M2: blocks B10, B11, B12, B13
to cover the (M1, M2) range, i guess one needs (B1, B13)
```

