### PR TITLE
Support authorization in handle alert feed

### DIFF
--- a/clients/graphql/client.go
+++ b/clients/graphql/client.go
@@ -1,8 +1,12 @@
 package graphql
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -30,7 +34,7 @@ func NewClient(url string) *Client {
 }
 
 func (ac *Client) GetAlerts(
-	ctx context.Context, input *AlertsInput,
+	ctx context.Context, input *AlertsInput, headers map[string]string,
 ) ([]*protocol.AlertEvent, error) {
 	if input.BlockSortDirection == "" {
 		input.BlockSortDirection = SortDesc
@@ -48,7 +52,7 @@ func (ac *Client) GetAlerts(
 	var alerts []*protocol.AlertEvent
 
 	for {
-		response, err := getAlerts(ctx, ac.client, input)
+		response, err := fetchAlerts(ctx, ac.url, input, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -71,6 +75,73 @@ func (ac *Client) GetAlerts(
 	}
 
 	return alerts, nil
+}
+
+func fetchAlerts(
+	ctx context.Context,
+	client string,
+	input *AlertsInput,
+	headers map[string]string,
+) (*getAlertsResponse, error) {
+	req := &graphql.Request{
+		OpName: "getAlerts",
+		Query:  getAlerts_Operation,
+		Variables: &__getAlertsInput{
+			Input: input,
+		},
+	}
+	var err error
+
+	var data getAlertsResponse
+	resp := &graphql.Response{Data: &data}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest(
+		http.MethodPost,
+		client,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq = httpReq.WithContext(ctx)
+
+	// set custom headers
+	for key, val := range headers {
+		httpReq.Header.Set(key, val)
+	}
+
+	// execute query
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		var respBody []byte
+		respBody, err = io.ReadAll(httpResp.Body)
+		if err != nil {
+			respBody = []byte(fmt.Sprintf("<unreadable: %v>", err))
+		}
+		return nil, fmt.Errorf("returned error %v: %s", httpResp.Status, respBody)
+	}
+
+	// parse response
+	err = json.NewDecoder(httpResp.Body).Decode(resp)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Errors) > 0 {
+		return nil, resp.Errors
+	}
+
+	return &data, err
 }
 
 func (v *getAlertsResponse) ToProto() []*protocol.AlertEvent {

--- a/clients/graphql/client_test.go
+++ b/clients/graphql/client_test.go
@@ -39,7 +39,7 @@ func TestAlertClient_GetAlerts(t *testing.T) {
 				ac := NewClient(tt.fields.url)
 
 				ctx := context.Background()
-				got, err := ac.GetAlerts(ctx, tt.args.input)
+				got, err := ac.GetAlerts(ctx, tt.args.input, nil)
 				if !tt.wantErr(t, err, "GetAlerts()") {
 					return
 				}

--- a/clients/graphql/client_test.go
+++ b/clients/graphql/client_test.go
@@ -32,6 +32,18 @@ func TestAlertClient_GetAlerts(t *testing.T) {
 				return err == nil
 			},
 		},
+		{
+			name: "invalid graphql api",
+			args: args{
+				input: &AlertsInput{
+					Bots: []string{"0x5e13c2f3a97c292695b598090056ba5d52f9dcc7790bcdaa8b6cd87c1a1ebc0f"},
+				},
+			},
+			fields: fields{url: "https://api.forta.network"},
+			wantErr: func(t assert.TestingT, err error, _ ...interface{}) bool {
+				return err == nil
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(

--- a/feeds/combiner.go
+++ b/feeds/combiner.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,10 +16,19 @@ import (
 	"github.com/forta-network/forta-core-go/clients/health"
 	"github.com/forta-network/forta-core-go/domain"
 	"github.com/forta-network/forta-core-go/protocol"
-	"github.com/forta-network/forta-core-go/protocol/transform"
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
 )
+
+type Subscriber struct {
+	BotID    string `json:"bot_id"`
+	BotOwner string `json:"bot_owner"`
+}
+
+type CombinerBotSubscription struct {
+	Subscription *protocol.CombinerBotSubscription `json:"subscription"`
+	Subscriber   Subscriber                        `json:"subscriber"`
+}
 
 var (
 	ErrCombinerStopReached   = fmt.Errorf("combiner stop reached")
@@ -39,7 +50,7 @@ type combinerFeed struct {
 	alertCh chan *domain.AlertEvent
 	client  *graphql.Client
 
-	botSubscriptions []*protocol.CombinerBotSubscription
+	botSubscriptions []*CombinerBotSubscription
 	botsMu           sync.RWMutex
 	// bloom filter could be a better choice but the miss rate was too high
 	// and we don't know the expected item count
@@ -51,29 +62,32 @@ type combinerFeed struct {
 	maxAlertAge time.Duration
 }
 
-func (cf *combinerFeed) Subscriptions() []*protocol.CombinerBotSubscription {
+func (cf *combinerFeed) Subscriptions() []*CombinerBotSubscription {
 	cf.botsMu.RLock()
 	defer cf.botsMu.RUnlock()
+
 	return cf.botSubscriptions
 }
-func (cf *combinerFeed) AddSubscription(subscription *protocol.CombinerBotSubscription) {
+
+func (cf *combinerFeed) AddSubscription(subscription *CombinerBotSubscription) {
 	cf.botsMu.Lock()
 	defer cf.botsMu.Unlock()
 
 	for _, s := range cf.botSubscriptions {
-		if transform.Equal(s, subscription) {
+		if isSameSubscription(s, subscription) {
 			return
 		}
 	}
 
 	cf.botSubscriptions = append(cf.botSubscriptions, subscription)
 }
-func (cf *combinerFeed) RemoveSubscription(subscription *protocol.CombinerBotSubscription) {
+
+func (cf *combinerFeed) RemoveSubscription(subscription *CombinerBotSubscription) {
 	cf.botsMu.Lock()
 	defer cf.botsMu.Unlock()
 
 	for i, s := range cf.botSubscriptions {
-		if transform.Equal(s, subscription) {
+		if isSameSubscription(s, subscription) {
 			cf.botSubscriptions = append(
 				cf.botSubscriptions[:i], cf.botSubscriptions[i+1:]...,
 			)
@@ -103,10 +117,6 @@ type CombinerFeedConfig struct {
 	CombinerCachePath string
 }
 
-func (cf *combinerFeed) IsStarted() bool {
-	return cf.started
-}
-
 func (cf *combinerFeed) Start() {
 	if !cf.started {
 		go cf.loop()
@@ -118,10 +128,6 @@ func (cf *combinerFeed) initialize() error {
 		cf.rateLimit = time.NewTicker(DefaultRatelimitDuration)
 	}
 	return nil
-}
-
-func (cf *combinerFeed) ForEachAlert(alertHandler func(evt *domain.AlertEvent) error) error {
-	return cf.forEachAlert([]cfHandler{{Handler: alertHandler}})
 }
 
 func (cf *combinerFeed) forEachAlert(alertHandlers []cfHandler) error {
@@ -172,7 +178,7 @@ func (cf *combinerFeed) forEachAlert(alertHandlers []cfHandler) error {
 }
 
 func (cf *combinerFeed) fetchAlertsAndHandle(
-	ctx context.Context, alertHandlers []cfHandler, subscription *protocol.CombinerBotSubscription, createdSince int64,
+	ctx context.Context, alertHandlers []cfHandler, subscription *CombinerBotSubscription, createdSince int64,
 	createdBefore int64,
 ) error {
 	var alerts []*protocol.AlertEvent
@@ -185,13 +191,14 @@ func (cf *combinerFeed) fetchAlertsAndHandle(
 			alerts, cErr = cf.client.GetAlerts(
 				cf.ctx,
 				&graphql.AlertsInput{
-					Bots:          []string{subscription.BotId},
+					Bots:          []string{subscription.Subscription.BotId},
 					CreatedSince:  uint(createdSince),
 					CreatedBefore: uint(createdBefore),
-					AlertIds:      subscription.AlertIds,
-					AlertId:       subscription.AlertId,
-					ChainId:       uint(subscription.ChainId),
+					AlertIds:      subscription.Subscription.AlertIds,
+					AlertId:       subscription.Subscription.AlertId,
+					ChainId:       uint(subscription.Subscription.ChainId),
 				},
+				subscriberInfoToHeaders(subscription.Subscriber),
 			)
 			if cErr != nil && errors.Is(cErr, context.DeadlineExceeded) {
 				log.WithError(cErr).Warn("error retrieving alerts")
@@ -205,6 +212,7 @@ func (cf *combinerFeed) fetchAlertsAndHandle(
 		return err
 	}
 
+	// alert post processing
 	for _, alert := range alerts {
 		if tooOld, age := alertIsTooOld(alert, cf.maxAlertAge); tooOld {
 			log.WithField("age", age).Warnf(
@@ -233,6 +241,7 @@ func (cf *combinerFeed) fetchAlertsAndHandle(
 				Feed:        time.Now().UTC(),
 				SourceAlert: alertCA,
 			},
+			SubscriberBotID: subscription.Subscriber.BotID,
 		}
 
 		for _, alertHandler := range alertHandlers {
@@ -243,18 +252,6 @@ func (cf *combinerFeed) fetchAlertsAndHandle(
 	}
 
 	return nil
-}
-
-// Name returns the name of this implementation.
-func (cf *combinerFeed) Name() string {
-	return "alert-feed"
-}
-
-// Health implements the health.Reporter interface.
-func (cf *combinerFeed) Health() health.Reports {
-	return health.Reports{
-		cf.lastAlert.GetReport("last-alert"),
-	}
 }
 
 func (cf *combinerFeed) loop() {
@@ -280,6 +277,41 @@ func (cf *combinerFeed) loop() {
 	}
 }
 
+//
+// Helper Methods
+//
+
+// subscriberInfoToHeaders converts subscriber information to map[string]string
+func subscriberInfoToHeaders(subscriber Subscriber) map[string]string {
+	return map[string]string{
+		"bot-id":    subscriber.BotID,
+		"bot-owner": subscriber.BotOwner,
+	}
+}
+
+// isSameSubscription checks for field-for-field equality for subscriptions.
+func isSameSubscription(a, b *CombinerBotSubscription) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	if a.Subscription.BotId != b.Subscription.BotId {
+		return false
+	}
+
+	if a.Subscription.AlertId != b.Subscription.AlertId {
+		return false
+	}
+
+	if a.Subscription.ChainId != b.Subscription.ChainId {
+		return false
+	}
+
+	sort.Strings(a.Subscription.AlertIds)
+	sort.Strings(b.Subscription.AlertIds)
+
+	return strings.EqualFold(strings.Join(a.Subscription.AlertIds, ","), strings.Join(b.Subscription.AlertIds, ","))
+}
 func alertIsTooOld(alert *protocol.AlertEvent, maxAge time.Duration) (bool, *time.Duration) {
 	if maxAge == 0 {
 		return false, nil
@@ -297,6 +329,18 @@ func alertIsTooOld(alert *protocol.AlertEvent, maxAge time.Duration) (bool, *tim
 	}
 
 	return age > maxAge, &age
+}
+
+// Name returns the name of this implementation.
+func (cf *combinerFeed) Name() string {
+	return "alert-feed"
+}
+
+// Health implements the health.Reporter interface.
+func (cf *combinerFeed) Health() health.Reports {
+	return health.Reports{
+		cf.lastAlert.GetReport("last-alert"),
+	}
 }
 
 func NewCombinerFeed(ctx context.Context, cfg CombinerFeedConfig) (AlertFeed, error) {
@@ -328,7 +372,7 @@ func NewCombinerFeed(ctx context.Context, cfg CombinerFeedConfig) (AlertFeed, er
 		client:           ac,
 		rateLimit:        cfg.RateLimit,
 		alertCh:          alerts,
-		botSubscriptions: []*protocol.CombinerBotSubscription{},
+		botSubscriptions: []*CombinerBotSubscription{},
 		cfg:              cfg,
 		alertCache:       alertCache,
 	}

--- a/feeds/combiner.go
+++ b/feeds/combiner.go
@@ -241,7 +241,6 @@ func (cf *combinerFeed) fetchAlertsAndHandle(
 				Feed:        time.Now().UTC(),
 				SourceAlert: alertCA,
 			},
-			SubscriberBotID: subscription.Subscriber.BotID,
 		}
 
 		for _, alertHandler := range alertHandlers {

--- a/feeds/combiner_test.go
+++ b/feeds/combiner_test.go
@@ -46,9 +46,11 @@ func Test_combinerFeed_Start(t *testing.T) {
 				)
 				r.NoError(err)
 				cf.AddSubscription(
-					&protocol.CombinerBotSubscription{
-						BotId:   "0x2bee737433c0c8cdbd924bbb68306cfd8abcf0e46a6ce8994fa7d474361bb186",
-						AlertId: "FORTA_1",
+					&CombinerBotSubscription{
+						Subscription: &protocol.CombinerBotSubscription{
+							BotId:   "0x2bee737433c0c8cdbd924bbb68306cfd8abcf0e46a6ce8994fa7d474361bb186",
+							AlertId: "FORTA_1",
+						},
 					},
 				)
 				errCh := cf.RegisterHandler(

--- a/feeds/interfaces.go
+++ b/feeds/interfaces.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/forta-network/forta-core-go/clients/health"
 	"github.com/forta-network/forta-core-go/domain"
-	"github.com/forta-network/forta-core-go/protocol"
 )
 
 // BlockFeed is a subscribable feed of blocks.
@@ -26,10 +25,9 @@ type TransactionFeed interface {
 // AlertFeed is a subscribable feed of alerts.
 type AlertFeed interface {
 	Start()
-	AddSubscription(subscription *protocol.CombinerBotSubscription)
-	RemoveSubscription(subscription *protocol.CombinerBotSubscription)
-	Subscriptions() []*protocol.CombinerBotSubscription
-	ForEachAlert(alertHandler func(evt *domain.AlertEvent) error) error
+	AddSubscription(subscription *CombinerBotSubscription)
+	RemoveSubscription(subscription *CombinerBotSubscription)
+	Subscriptions() []*CombinerBotSubscription
 	RegisterHandler(alertHandler func(evt *domain.AlertEvent) error) <-chan error
 	health.Reporter
 }

--- a/inspect/proxy_api_test.go
+++ b/inspect/proxy_api_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 var testProxyEnv struct {
-	ProxyAPI string `envconfig:"proxy_api" default:"https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"`
+	ProxyAPI string `envconfig:"proxy_api" default:"https://rpc.ankr.com/eth_goerli"`
 }
 
 func init() {


### PR DESCRIPTION
Extends the CombinerBotSubscription struct to contain bot owner and bot id information and uses them in graphql API authorization

Enables custom header support for graphql requests