### PR TITLE
Improve combiner subscription uniqueness

### DIFF
--- a/domain/events.go
+++ b/domain/events.go
@@ -314,8 +314,9 @@ func (t *AlertEvent) ToMessage() (*protocol.AlertEvent, error) {
 }
 
 type Subscriber struct {
-	BotID    string `json:"bot_id"`
+	BotID        string `json:"bot_id"`
 	BotOwner string `json:"bot_owner"`
+	BotImage string `json:"bot_image_hash"`
 }
 
 type CombinerBotSubscription struct {
@@ -338,7 +339,7 @@ func (c *CombinerBotSubscription) Equal(b *CombinerBotSubscription) bool {
 
 	// Subscriber-specific uniqueness checks. Since the protocol enforces subscription fees, subscriptions from 2 different bots or bot owners can not
 	// be treated as same, because one can fail while the other succeeds.
-	if c.Subscriber.BotID != b.Subscriber.BotID || c.Subscriber.BotOwner != b.Subscriber.BotOwner {
+	if c.Subscriber.BotID != b.Subscriber.BotID || c.Subscriber.BotOwner != b.Subscriber.BotOwner || c.Subscriber.BotImage != b.Subscriber.BotImage {
 		return false
 	}
 

--- a/feeds/combiner.go
+++ b/feeds/combiner.go
@@ -2,7 +2,6 @@ package feeds
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/forta-network/forta-core-go/domain"
 	"github.com/forta-network/forta-core-go/protocol"
 	log "github.com/sirupsen/logrus"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 var (
@@ -252,18 +250,8 @@ func (cf *combinerFeed) fetchAlerts(ctx context.Context, logger *log.Entry, subs
 			if cErr != nil {
 				logger.WithError(cErr).Warn("error retrieving alerts")
 
-				// any graphql error is non-retryable
-				errList, ok := cErr.(gqlerror.List)
-				if ok {
-					return backoff.Permanent(errList)
-				}
-
-				// it is safe to return nil on context deadlines, no need for error handling.
-				if errors.Is(cErr, context.DeadlineExceeded) {
-					return nil
-				}
-
-				return cErr
+				// make any error is non-retryable
+				return backoff.Permanent(cErr)
 			}
 			return nil
 		},

--- a/feeds/combiner.go
+++ b/feeds/combiner.go
@@ -412,7 +412,7 @@ func NewCombinerFeed(ctx context.Context, cfg CombinerFeedConfig) (AlertFeed, er
 func NewCombinerFeedWithClient(ctx context.Context, cfg CombinerFeedConfig, client graphql.Client) (AlertFeed, error) {
 	alerts := make(chan *domain.AlertEvent, 10)
 
-	combinerCache, err := newCombinerCache(cfg.CombinerCachePath)
+	c, err := newCombinerCache(cfg.CombinerCachePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize combiner cache: %v", err)
 	}
@@ -430,7 +430,7 @@ func NewCombinerFeedWithClient(ctx context.Context, cfg CombinerFeedConfig, clie
 		alertCh:          alerts,
 		botSubscriptions: []*domain.CombinerBotSubscription{},
 		cfg:              cfg,
-		combinerCache:    combinerCache,
+		combinerCache:    c,
 	}
 
 	return bf, nil

--- a/feeds/combiner.go
+++ b/feeds/combiner.go
@@ -182,7 +182,7 @@ func (cf *combinerFeed) forEachAlert(alertHandlers []cfHandler) error {
 
 			err := cf.fetchAlertsAndHandle(cf.ctx, alertHandlers, subscription, lowerBound.Milliseconds(), upperBound)
 			if err != nil {
-				logger.WithError(err).Warn("failed to fetch alerts")
+				logger.WithError(err).Warn("failed to fetch alerts and handle")
 			}
 		}
 

--- a/feeds/combiner_cache.go
+++ b/feeds/combiner_cache.go
@@ -31,6 +31,8 @@ func newCombinerCache(path string) (*combinerCache, error) {
 
 		err = json.Unmarshal(d, &m)
 		if err != nil {
+			m = make(map[string]cache.Item)
+
 			tErr := os.RemoveAll(path)
 			if tErr != nil {
 				return nil, fmt.Errorf("can not remove malformed combiner cache, :%v", tErr)

--- a/feeds/combiner_cache.go
+++ b/feeds/combiner_cache.go
@@ -52,12 +52,12 @@ func newCombinerCache(path string) (*combinerCache, error) {
 }
 
 func (c *combinerCache) Exists(subscription *domain.CombinerBotSubscription, alert *protocol.AlertEvent) bool {
-	_, exists := c.cache.Get(encodeAlertCacheKey(subscription.Subscriber.BotID, alert.Alert.Hash))
+	_, exists := c.cache.Get(encodeAlertCacheKey(subscription.Subscriber.BotID, subscription.Subscriber.BotImage, alert.Alert.Hash))
 	return exists
 }
 
 func (c *combinerCache) Set(subscription *domain.CombinerBotSubscription, alert *protocol.AlertEvent) {
-	c.cache.Set(encodeAlertCacheKey(subscription.Subscriber.BotID, alert.Alert.Hash), struct{}{}, cache.DefaultExpiration)
+	c.cache.Set(encodeAlertCacheKey(subscription.Subscriber.BotID, subscription.Subscriber.BotImage, alert.Alert.Hash), struct{}{}, cache.DefaultExpiration)
 }
 
 // DumpToFile dumps the current cache into a file in JSON format, so that the cache can be used in a persistent way.
@@ -83,6 +83,6 @@ func (c *combinerCache) DumpToFile(filePath string) error {
 
 // encodeAlertCacheKey must encode alerts to prevent missing subscriptions to the same target bot
 // from several deployed bots
-func encodeAlertCacheKey(subscriberBotID, alertHash string) string {
-	return fmt.Sprintf("%s|%s", subscriberBotID, alertHash)
+func encodeAlertCacheKey(subscriberBotID, image, alertHash string) string {
+	return fmt.Sprintf("%s|%s|%s", subscriberBotID, image, alertHash)
 }

--- a/feeds/combiner_test.go
+++ b/feeds/combiner_test.go
@@ -77,7 +77,7 @@ func Test_combinerFeed_Start(t *testing.T) {
 						Subscription: &protocol.CombinerBotSubscription{
 							BotId: subscribeeBot,
 						},
-						Subscriber: &domain.Subscriber{BotID: subscriberBot, BotOwner: "0x"},
+						Subscriber: &domain.Subscriber{BotID: subscriberBot, BotOwner: "0x", BotImage: "0x123"},
 					},
 				)
 				r.NoError(err)


### PR DESCRIPTION
Improving subscription uniqueness to prevent a possible race condition
Case:

- Bot dev updates bot image
  - [async] handle adding subscriptions in the new version
  - [async] handle removing subscriptions in the old version
    - race: removal handled after addition, so identical subscirptions between two versions are removed

This PR adds bot image field to subscriptions to prevent this issue