### PR TITLE
Account available memory in sla calculation

### DIFF
--- a/inspect/scorecalc/calculator.go
+++ b/inspect/scorecalc/calculator.go
@@ -13,7 +13,7 @@ const (
 	DefaultMinUploadSpeedInMbps   = 3  // 3 mbps
 	DefaultEarliestBlock          = inspect.VeryOldBlockNumber
 	DefaultMinTotalMemory         = 8e9 // 8 gigabytes
-	DefaultMinAvailableMemory     = 5e7 // 50 megabytes
+	DefaultMinAvailableMemory     = 2e9 // 2 gigabytes
 )
 
 // Errors

--- a/inspect/scorecalc/pass_fail_calculator.go
+++ b/inspect/scorecalc/pass_fail_calculator.go
@@ -58,6 +58,11 @@ func (c *chainPassFailCalculator) CalculateScore(results *inspect.InspectionResu
 		return 0, nil
 	}
 
+	// available memory should be at least DefaultMinAvailableMemory
+	if results.Indicators[inspect.IndicatorResourcesMemoryAvailable] < c.config.MinAvailableMemory {
+		return 0, nil
+	}
+
 	if results.Inputs.IsETH2 && results.Indicators[inspect.IndicatorScanAPIIsETH2] == inspect.ResultFailure {
 		return 0, nil
 	}


### PR DESCRIPTION
Pass-fail score calculator will return 0, if there's less than 2GB of memory available