### PR TITLE
Add new metadata fields

### DIFF
--- a/manifest/types.go
+++ b/manifest/types.go
@@ -6,7 +6,6 @@ import "github.com/forta-network/forta-core-go/utils"
 type AgentManifest struct {
 	From            *string                       `json:"from"`
 	Name            *string                       `json:"name"`
-	DisplayName     *string                       `json:"displayName"`
 	Description     *string                       `json:"description"`
 	LongDescription *string                       `json:"longDescription"`
 	AgentID         *string                       `json:"agentId"`

--- a/manifest/types.go
+++ b/manifest/types.go
@@ -4,17 +4,22 @@ import "github.com/forta-network/forta-core-go/utils"
 
 // AgentManifest represents the dev-provided properties of an agent
 type AgentManifest struct {
-	From           *string                       `json:"from"`
-	Name           *string                       `json:"name"`
-	AgentID        *string                       `json:"agentId"`
-	AgentIDHash    *string                       `json:"agentIdHash"`
-	Version        *string                       `json:"version"`
-	Timestamp      *string                       `json:"timestamp"`
-	ImageReference *string                       `json:"imageReference"`
-	Repository     *string                       `json:"repository"`
-	Documentation  *string                       `json:"documentation"`
-	ChainIDs       []int64                       `json:"chainIds"`
-	ChainSettings  map[string]AgentChainSettings `json:"chainSettings"`
+	From            *string                       `json:"from"`
+	Name            *string                       `json:"name"`
+	DisplayName     *string                       `json:"displayName"`
+	Description     *string                       `json:"description"`
+	LongDescription *string                       `json:"longDescription"`
+	AgentID         *string                       `json:"agentId"`
+	AgentIDHash     *string                       `json:"agentIdHash"`
+	Version         *string                       `json:"version"`
+	Timestamp       *string                       `json:"timestamp"`
+	ImageReference  *string                       `json:"imageReference"`
+	Repository      *string                       `json:"repository"`
+	PromoUrl        *string                       `json:"promoUrl"`
+	LicenseUrl      *string                       `json:"licenseUrl"`
+	Documentation   *string                       `json:"documentation"`
+	ChainIDs        []int64                       `json:"chainIds"`
+	ChainSettings   map[string]AgentChainSettings `json:"chainSettings"`
 }
 
 // AgentChainSettings is the per-chain configuration of a bot.


### PR DESCRIPTION
In the new bot page, there are fields for extra information which need to be supported by the SDK and backend:

- ~display name (allows devs to set a human-readable name from CLI and not just package.json name)~

- short description (is this already available? i.e. package.json description)

- long description

- promotional URL

- license URL