### PR TITLE
Increase combiner request batch size

### DIFF
--- a/clients/graphql/batch.go
+++ b/clients/graphql/batch.go
@@ -153,10 +153,6 @@ func makeRequest(ctx context.Context, client string, req *graphql.Request, heade
 	}
 	defer httpResp.Body.Close()
 
-	if httpResp.StatusCode == http.StatusInternalServerError {
-		return nil, ErrResponseSizeTooBig
-	}
-
 	if httpResp.StatusCode != http.StatusOK {
 		var respBody []byte
 		respBody, err = io.ReadAll(httpResp.Body)

--- a/clients/graphql/models.go
+++ b/clients/graphql/models.go
@@ -151,6 +151,9 @@ func createGetAlertsQuery(inputs []*AlertsInput) (string, map[string]interface{}
 	variables := make(map[string]interface{})
 	var queryBuilder strings.Builder
 
+	// Define fragment
+	queryBuilder.WriteString(getAlertsFragment)
+
 	// Define the operation with necessary variables
 	queryBuilder.WriteString("query getAlerts(")
 	for i := range inputs {
@@ -294,73 +297,79 @@ pageInfo {
 	}
 }
 alerts {
-	alertId
-	addresses
-	contracts {
-		name
-		projectId
-	}
-	createdAt
-	description
-	hash
-	metadata
-	name
-	projects {
-		id
-	}
-	protocol
-	scanNodeCount
-	severity
-	source {
-		transactionHash
-		bot {
-			chainIds
-			createdAt
-			description
-			developer
-			docReference
-			enabled
-			id
-			image
-			name
-			reference
-			repository
-			projects
-			scanNodes
-			version
-		}
-		block {
-			number
-			hash
-			timestamp
-			chainId
-		}
-		sourceAlert {
-			hash
-			botId
-			timestamp
-			chainId
-		}
-	}
-	alertDocumentType
-	findingType
-	relatedAlerts
-	chainId
-	labels {
-		label
-		confidence
-		entity
-		entityType
-		remove
-		metadata
-		uniqueKey
-		embedding
-	}
-	addressBloomFilter {
-		bitset
-		itemCount
-		k
-		m
-	}
+	...alertDetails
+}
+`
+
+const getAlertsFragment = `
+fragment alertDetails on Alert {
+  alertId
+  addresses
+  contracts {
+    name
+    projectId
+  }
+  createdAt
+  description
+  hash
+  metadata
+  name
+  projects {
+    id
+  }
+  protocol
+  scanNodeCount
+  severity
+  source {
+    transactionHash
+    bot {
+      chainIds
+      createdAt
+      description
+      developer
+      docReference
+      enabled
+      id
+      image
+      name
+      reference
+      repository
+      projects
+      scanNodes
+      version
+    }
+    block {
+      number
+      hash
+      timestamp
+      chainId
+    }
+    sourceAlert {
+      hash
+      botId
+      timestamp
+      chainId
+    }
+  }
+  alertDocumentType
+  findingType
+  relatedAlerts
+  chainId
+  labels {
+    label
+    confidence
+    entity
+    entityType
+    remove
+    metadata
+    uniqueKey
+    embedding
+  }
+  addressBloomFilter {
+    bitset
+    itemCount
+    k
+    m
+  }
 }
 `

--- a/feeds/combiner.go
+++ b/feeds/combiner.go
@@ -23,7 +23,7 @@ var (
 )
 
 const (
-	DefaultBatchSize = 10
+	DefaultBatchSize = 50
 )
 
 type cfHandler struct {


### PR DESCRIPTION
Changes:
- Starts using fragments to reduce request footprint (see example request below)
- increases batch size to 50. this seems to work well running locally against production public API. It'll retry with half the batch size in worst case scenario
- Removed internal server error handler. Since the alert fetcher retries on all errors, needs unnecessary complexity

Improved query example:
```graphql
fragment alertDetails on Alert {
    alertId
    addresses
    contracts {
        name
        projectId
    }
    createdAt
    description
    hash
    metadata
    name
    projects {
        id
    }
    protocol
    scanNodeCount
    severity
    source {
        transactionHash
        bot {
            chainIds
            createdAt
            description
            developer
            docReference
            enabled
            id
            image
            name
            reference
            repository
            projects
            scanNodes
            version
        }
        block {
            number
            hash
            timestamp
            chainId
        }
        sourceAlert {
            hash
            botId
            timestamp
            chainId
        }
    }
    alertDocumentType
    findingType
    relatedAlerts
    chainId
    labels {
        label
        confidence
        entity
        entityType
        remove
        metadata
        uniqueKey
        embedding
    }
    addressBloomFilter {
        bitset
        itemCount
        k
        m
    }
}

query getAlerts($input0: AlertsInput,$input1: AlertsInput,$input2: AlertsInput) {
    alerts0: alerts(input: $input0) { pageInfo { hasNextPage endCursor { alertId blockNumber } } alerts {...alertDetails}}
    alerts1: alerts(input: $input1) { pageInfo { hasNextPage endCursor { alertId blockNumber } } alerts {...alertDetails} }
    alerts2: alerts(input: $input2) { pageInfo { hasNextPage endCursor { alertId blockNumber } } alerts {...alertDetails} }
}
```