### PR TITLE
Disable HTTP/2 in default client

### DIFF
--- a/utils/httpclient/client.go
+++ b/utils/httpclient/client.go
@@ -1,11 +1,17 @@
 package httpclient
 
 import (
+	"crypto/tls"
 	"net/http"
 	"time"
 )
 
-// Default is the default HTTP client to use.
+// Default is the default HTTP client to use. HTTP/2 is disabled.
 var Default = &http.Client{
 	Timeout: time.Second * 30,
+	// Disable HTTP/2
+	// Reason: https://www.bentasker.co.uk/posts/blog/software-development/golang-net-http-net-http-2-does-not-reliably-close-failed-connections-allowing-attempted-reuse.html
+	Transport: &http.Transport{
+		TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
+	},
 }


### PR DESCRIPTION
Based on: 
- https://www.bentasker.co.uk/posts/blog/software-development/golang-net-http-net-http-2-does-not-reliably-close-failed-connections-allowing-attempted-reuse.html#16_mins
- https://stackoverflow.com/questions/67770829/go-http-request-falls-back-to-http2-even-when-force-attempt-is-set-to-false

https://pkg.go.dev/net/http#hdr-HTTP_2
> Starting with Go 1.6, the http package has transparent support for the HTTP/2 protocol when using HTTPS. Programs that must disable HTTP/2 can do so by setting [Transport.TLSNextProto] (for clients) or [Server.TLSNextProto] (for servers) to a non-nil, empty map.